### PR TITLE
Expose StartupProperties to ASPNET Core apps

### DIFF
--- a/src/OpenRasta.Hosting.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/OpenRasta.Hosting.AspNetCore/ApplicationBuilderExtensions.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.Extensions.DependencyInjection;
+using OpenRasta.Concordia;
 using OpenRasta.Configuration;
 using OpenRasta.DI;
 using OpenRasta.Hosting.Katana;
@@ -13,7 +14,8 @@ namespace OpenRasta.Hosting.AspNetCore
     public static IApplicationBuilder UseOpenRasta(
       this IApplicationBuilder app,
       IConfigurationSource configurationSource,
-      IDependencyResolverAccessor dependencyResolver = null)
+      IDependencyResolverAccessor dependencyResolver = null,
+      StartupProperties startupProperties = null)
     {
       return app
         .Use(async (context, next) =>
@@ -31,7 +33,8 @@ namespace OpenRasta.Hosting.AspNetCore
           builder.UseOpenRasta(
             configurationSource,
             dependencyResolver,
-            app.ApplicationServices.GetService<IApplicationLifetime>().ApplicationStopping));
+            app.ApplicationServices.GetService<IApplicationLifetime>().ApplicationStopping,
+            startupProperties));
     }
   }
 }

--- a/src/OpenRasta/Hosting/Owin/AspNetCoreBuildFuncExtensions.cs
+++ b/src/OpenRasta/Hosting/Owin/AspNetCoreBuildFuncExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using OpenRasta.Concordia;
 using OpenRasta.Configuration;
 using OpenRasta.DI;
 using AppFunc = System.Func<System.Collections.Generic.IDictionary<string, object>, System.Threading.Tasks.Task>;
@@ -15,9 +16,10 @@ namespace OpenRasta.Hosting.Katana
       this Action<MidFunc> builder,
       IConfigurationSource configurationSource,
       IDependencyResolverAccessor dependencyResolver = null,
-      CancellationToken onAppDisposing = default(CancellationToken))
+      CancellationToken onAppDisposing = default(CancellationToken),
+      StartupProperties startupProperties = null)
     {
-      builder(new OpenRastaMiddleware(configurationSource, dependencyResolver, onAppDisposing).ToMidFunc());
+      builder(new OpenRastaMiddleware(configurationSource, dependencyResolver, onAppDisposing, startupProperties).ToMidFunc());
       return builder;
     }
   }
@@ -26,9 +28,10 @@ namespace OpenRasta.Hosting.Katana
   {
     public static MidFunc CreateMiddleware(IConfigurationSource configurationSource,
       IDependencyResolverAccessor dependencyResolver = null,
-      CancellationToken onAppDisposing = default(CancellationToken))
+      CancellationToken onAppDisposing = default(CancellationToken),
+      StartupProperties startupProperties = null)
     {
-      return new OpenRastaMiddleware(configurationSource, dependencyResolver, onAppDisposing).ToMidFunc();
+      return new OpenRastaMiddleware(configurationSource, dependencyResolver, onAppDisposing, startupProperties).ToMidFunc();
     }
   }
 }

--- a/src/OpenRasta/Hosting/Owin/OpenRastaMiddleware.cs
+++ b/src/OpenRasta/Hosting/Owin/OpenRastaMiddleware.cs
@@ -7,6 +7,7 @@ using OpenRasta.Diagnostics;
 using OpenRasta.DI;
 using OpenRasta.Web;
 using AppFunc = System.Func<System.Collections.Generic.IDictionary<string, object>, System.Threading.Tasks.Task>;
+using OpenRasta.Concordia;
 
 namespace OpenRasta.Hosting.Katana
 {
@@ -57,13 +58,16 @@ namespace OpenRasta.Hosting.Katana
     static readonly object SyncRoot = new object();
     HostManager _hostManager;
     readonly OwinHost _host;
+    private readonly StartupProperties _startupProperties;
 
     public OpenRastaMiddleware(
       IConfigurationSource options,
       IDependencyResolverAccessor resolverAccesor = null,
-      CancellationToken onDisposing = default(CancellationToken))
+      CancellationToken onDisposing = default(CancellationToken),
+      StartupProperties startupProperties = null)
     {
       _host = new OwinHost(options, resolverAccesor);
+      _startupProperties = startupProperties ?? new StartupProperties();
       TryInitializeHosting(onDisposing);
     }
 
@@ -109,7 +113,7 @@ namespace OpenRasta.Hosting.Katana
         _hostManager = hostManager;
         try
         {
-          _host.RaiseStart();
+          _host.RaiseStart(_startupProperties);
         }
         catch
         {

--- a/src/OpenRasta/Hosting/Owin/OwinHost.cs
+++ b/src/OpenRasta/Hosting/Owin/OwinHost.cs
@@ -12,14 +12,18 @@ namespace OpenRasta.Hosting.Katana
 {
   public class OwinHost : IHost, IHostStartWithStartupProperties
   {
-    public OwinHost(
+     private readonly StartupProperties _startupProperties;
+
+     public OwinHost(
       IConfigurationSource configuration,
       IDependencyResolverAccessor resolverAccesor = null,
-      string applicationVirtualPath = "/")
+      string applicationVirtualPath = "/",
+      StartupProperties startupProperties = null)
     {
       ConfigurationSource = configuration;
       ResolverAccessor = resolverAccesor;
       ApplicationVirtualPath = applicationVirtualPath;
+      _startupProperties = startupProperties;
     }
 
     public IConfigurationSource ConfigurationSource { get; set; }
@@ -56,7 +60,7 @@ namespace OpenRasta.Hosting.Katana
     internal async Task<ICommunicationContext> ProcessRequestAsync(IOwinContext owinContext)
     {
       var commContext = new OwinCommunicationContext(owinContext, TraceSourceLogger.Instance);
-      
+
       var ambientContext = new AmbientContext();
 
       try
@@ -90,7 +94,7 @@ namespace OpenRasta.Hosting.Katana
 
     internal virtual void RaiseStart()
     {
-      RaiseStart(new StartupProperties());
+      RaiseStart(_startupProperties);
     }
 
     public void RaiseStop()


### PR DESCRIPTION
Various aspects of OpenRasta's pipeline can be configured via a `StartupProperties` object, but I couldn't see a way to manipulate the instance that gets passed down to the host from an ASP.NET Core app.

These changes allow an instance to be provided to the host from the running application.

---

Hi there!

Thank you so much for contributing this pull request. We love when the community
steps up and share, and we're enormously thankful.

You don't have to do all of those following things, they are what we try and get 
done for code coming in:

 - [x] the code
 - [ ] If it's a non-trivial piece of code, signing a CLA
 - [ ] If it breaks, change, fix or add to existing behaviour, updating
       CHANGELOG.md
 - [ ] If it's a bug fix, tests in the Tests `project`, or scenarios in the `TestRig`.
 - [ ] On top of HEAD, unless it's a bugfix on a previous version
 - [ ] VERSION file updated if not creating a pull-request on top of `master`

If those are needed, and you haven't and can't, we thank you enormously for your
contribution, and we'll add those before merging the pull request.

Thanks!

The OpenRasta community
