### PR TITLE
Trace Less

### DIFF
--- a/src/OpenRasta.Hosting.AspNet/AspNetCommunicationContext.cs
+++ b/src/OpenRasta.Hosting.AspNet/AspNetCommunicationContext.cs
@@ -20,7 +20,7 @@ namespace OpenRasta.Hosting.AspNet
         if (context.Items.Contains(COMM_CONTEXT_KEY))
           return (AspNetCommunicationContext) context.Items[COMM_CONTEXT_KEY];
         var orContext = new AspNetCommunicationContext(
-          TraceSourceLogger.Instance,
+          DefaultLogger.Instance,
           context,
           new AspNetRequest(context),
           new AspNetResponse(context));

--- a/src/OpenRasta.Hosting.AspNet/AspNetResponse.cs
+++ b/src/OpenRasta.Hosting.AspNet/AspNetResponse.cs
@@ -20,7 +20,7 @@ namespace OpenRasta.Hosting.AspNet
     public IHttpEntity Entity { get; }
     public HttpHeaderDictionary Headers { get; }
     public bool HeadersSent => _headersSent; //|| _nativeHeadersSent;
-    readonly ILogger log = TraceSourceLogger.Instance;
+    readonly ILogger log = DefaultLogger.Instance;
 
     bool _headersSent;
 //    bool _nativeHeadersSent;

--- a/src/OpenRasta.Hosting.AspNet/OpenRastaModuleAsync.cs
+++ b/src/OpenRasta.Hosting.AspNet/OpenRastaModuleAsync.cs
@@ -12,7 +12,7 @@ namespace OpenRasta.Hosting.AspNet
 {
   public class OpenRastaModuleAsync : IHttpModule
   {
-    private static ILogger _log = TraceSourceLogger.Instance;
+    private static ILogger _log = DefaultLogger.Instance;
     public void Dispose()
     {
       _host.Value.host.RaiseStop();

--- a/src/OpenRasta/DI/Internal/ObjectBuilder.cs
+++ b/src/OpenRasta/DI/Internal/ObjectBuilder.cs
@@ -13,7 +13,7 @@ namespace OpenRasta.DI.Internal
       ResolveContext = context;
     }
 
-    ILogger Log { get; } = TraceSourceLogger.Instance;
+    ILogger Log => DefaultLogger.Instance;
 
     ResolveContext ResolveContext { get; }
 

--- a/src/OpenRasta/Diagnostics/TraceSourceLogger.cs
+++ b/src/OpenRasta/Diagnostics/TraceSourceLogger.cs
@@ -4,6 +4,11 @@ using OpenRasta.DI;
 
 namespace OpenRasta.Diagnostics
 {
+  public static class DefaultLogger
+  {
+    public static ILogger Instance { get; set; } = new TraceSourceLogger();
+  }
+
   public class TraceSourceLogger<T> : TraceSourceLogger, ILogger<T> where T : ILogSource
   {
     public TraceSourceLogger()
@@ -16,8 +21,6 @@ namespace OpenRasta.Diagnostics
   {
     readonly TraceSource _source;
     static readonly TraceSource DefaultTraceSource = new TraceSource("openrasta");
-
-    public static readonly ILogger Instance = new TraceSourceLogger();
 
     public TraceSourceLogger() : this(DefaultTraceSource)
     {

--- a/src/OpenRasta/Diagnostics/TraceSourceLogger.cs
+++ b/src/OpenRasta/Diagnostics/TraceSourceLogger.cs
@@ -22,6 +22,12 @@ namespace OpenRasta.Diagnostics
     readonly TraceSource _source;
     static readonly TraceSource DefaultTraceSource = new TraceSource("openrasta");
 
+    /// <summary>
+    /// Levels to trace for all <see cref="TraceSourceLogger"/>.
+    /// Default: <see cref="SourceLevels.Warning"/>.
+    /// </summary>
+    public static SourceLevels Levels { get; set; } = SourceLevels.Warning;
+
     public TraceSourceLogger() : this(DefaultTraceSource)
     {
     }
@@ -53,6 +59,9 @@ namespace OpenRasta.Diagnostics
 
     public IDisposable Operation(object source, string name)
     {
+      if (!Levels.HasFlag(SourceLevels.ActivityTracing))
+        return EmptyDisposable.Instance;
+
       var msg = $"{source.GetType().Name} ({name})";
       _source.TraceData(TraceEventType.Start, 1, msg);
       Trace.CorrelationManager.StartLogicalOperation(source.GetType().Name);
@@ -62,16 +71,25 @@ namespace OpenRasta.Diagnostics
 
     public void WriteDebug(string message, params object[] format)
     {
+      if (!Levels.HasFlag(SourceLevels.Verbose))
+        return;
+
       _source.TraceData(TraceEventType.Verbose, 0, message.With(format));
     }
 
     public void WriteError(string message, params object[] format)
     {
+      if (!Levels.HasFlag(SourceLevels.Error))
+        return;
+
       _source.TraceData(TraceEventType.Error, 0, message.With(format));
     }
 
     public void WriteException(Exception e)
     {
+      if (!Levels.HasFlag(SourceLevels.Error))
+        return;
+
       if (e == null)
         return;
       WriteError("An error of type {0} has been thrown", e.GetType());
@@ -81,11 +99,17 @@ namespace OpenRasta.Diagnostics
 
     public void WriteInfo(string message, params object[] format)
     {
+      if (!Levels.HasFlag(SourceLevels.Information))
+        return;
+
       _source.TraceData(TraceEventType.Information, 0, message.With(format));
     }
 
     public void WriteWarning(string message, params object[] format)
     {
+      if (!Levels.HasFlag(SourceLevels.Warning))
+        return;
+
       _source.TraceData(TraceEventType.Warning, 0, message.With(format));
     }
 
@@ -99,6 +123,13 @@ namespace OpenRasta.Diagnostics
       {
         Source.TraceData(TraceEventType.Stop, 1, $"Exiting {Initiator.GetType().Name}: {Message}");
       }
+    }
+
+    class EmptyDisposable : IDisposable
+    {
+      public static readonly IDisposable Instance = new EmptyDisposable();
+
+      public void Dispose() { }
     }
   }
 }

--- a/src/OpenRasta/Hosting/HostManager.cs
+++ b/src/OpenRasta/Hosting/HostManager.cs
@@ -98,7 +98,7 @@ namespace OpenRasta.Hosting
     void AssignResolver()
     {
       Resolver = Host.ResolverAccessor?.Resolver ?? new InternalDependencyResolver();
-      Log = Resolver.Resolve<IEnumerable<ILogger>>().LastOrDefault() ?? TraceSourceLogger.Instance;
+      Log = Resolver.Resolve<IEnumerable<ILogger>>().LastOrDefault() ?? DefaultLogger.Instance;
 
       Log.WriteDebug("Using dependency resolver of type {0}", Resolver.GetType());
     }

--- a/src/OpenRasta/Hosting/Owin/OwinHost.cs
+++ b/src/OpenRasta/Hosting/Owin/OwinHost.cs
@@ -59,7 +59,7 @@ namespace OpenRasta.Hosting.Katana
 
     internal async Task<ICommunicationContext> ProcessRequestAsync(IOwinContext owinContext)
     {
-      var commContext = new OwinCommunicationContext(owinContext, TraceSourceLogger.Instance);
+      var commContext = new OwinCommunicationContext(owinContext, DefaultLogger.Instance);
 
       var ambientContext = new AmbientContext();
 

--- a/src/OpenRasta/Pipeline/Contributors/ResponseEntityWriterContributor.cs
+++ b/src/OpenRasta/Pipeline/Contributors/ResponseEntityWriterContributor.cs
@@ -15,7 +15,7 @@ namespace OpenRasta.Pipeline.Contributors
   {
     readonly IDependencyResolver _resolver;
 
-    public ILogger Log { get; } = TraceSourceLogger.Instance;
+    public ILogger Log => DefaultLogger.Instance;
 
     public ResponseEntityWriterContributor(IDependencyResolver resolver)
     {

--- a/src/OpenRasta/Pipeline/LoggingMiddleware.cs
+++ b/src/OpenRasta/Pipeline/LoggingMiddleware.cs
@@ -7,7 +7,7 @@ namespace OpenRasta.Pipeline
 {
   public class LoggingMiddleware : IPipelineMiddleware
   {
-    static readonly ILogger Log = TraceSourceLogger.Instance;
+    static ILogger Log => DefaultLogger.Instance;
     readonly IPipelineMiddleware _next;
     readonly string _log;
 

--- a/src/OpenRasta/Pipeline/ThreePhasePipelineInitializer.cs
+++ b/src/OpenRasta/Pipeline/ThreePhasePipelineInitializer.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRasta.Concordia;
 using OpenRasta.Diagnostics;
-using OpenRasta.DI;
 using OpenRasta.Pipeline.CallGraph;
 
 namespace OpenRasta.Pipeline
@@ -12,7 +11,7 @@ namespace OpenRasta.Pipeline
   {
     readonly IEnumerable<IPipelineContributor> _contributors;
     readonly IGenerateCallGraphs _callGrapher;
-    static ILogger Log { get; } = TraceSourceLogger.Instance;
+    static ILogger Log => DefaultLogger.Instance;
 
     public ThreePhasePipelineInitializer(
       IEnumerable<IPipelineContributor> contributors,


### PR DESCRIPTION
1. Replace `TraceSourceLogger.Instances` with `DefaultLogger.Instance`, a seam we could use to insert a custom `ILogger`
    - See `DefaultDependencyRegistrar` for additional logger-related setup
2. Add `TraceSourceLogger.Level` to prevent calling `TraceData()` (which seems to always lock!) if we're just going to ignore it
    - Default: `Warning`