### PR TITLE
CloseRasta: Unhandle Exceptions [OLO-103725]

### DIFF
--- a/src/OpenRasta/Hosting/Owin/OpenRastaMiddleware.cs
+++ b/src/OpenRasta/Hosting/Owin/OpenRastaMiddleware.cs
@@ -79,7 +79,7 @@ namespace OpenRasta.Hosting.Katana
       {
         commContext = await _host.ProcessRequestAsync(owinContext);
       }
-      catch (Exception e) when (HeadersSent == false)
+      catch (Exception e) when (HeadersSent == false && _startupProperties.OpenRasta.Errors.HandleAllExceptions)
       {
         owinContext.Response.StatusCode = 500;
         owinContext.Response.Write(e.ToString());

--- a/src/OpenRasta/Hosting/Owin/OpenRastaMiddleware.cs
+++ b/src/OpenRasta/Hosting/Owin/OpenRastaMiddleware.cs
@@ -75,16 +75,8 @@ namespace OpenRasta.Hosting.Katana
     {
       ICommunicationContext commContext;
       owinContext.Response.OnSendingHeaders(_ => this.HeadersSent = true, null);
-      try
-      {
-        commContext = await _host.ProcessRequestAsync(owinContext);
-      }
-      catch (Exception e) when (HeadersSent == false && _startupProperties.OpenRasta.Errors.HandleAllExceptions)
-      {
-        owinContext.Response.StatusCode = 500;
-        owinContext.Response.Write(e.ToString());
-        return;
-      }
+
+      commContext = await _host.ProcessRequestAsync(owinContext);
 
       if (commContext != null &&
           commContext.OperationResult is OperationResult.NotFound notFound &&

--- a/src/Tests/Hosting.Owin/hosting_on_pure_owin_on_asp_net_core.cs
+++ b/src/Tests/Hosting.Owin/hosting_on_pure_owin_on_asp_net_core.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using OpenRasta.Hosting.Katana;
@@ -20,10 +21,37 @@ namespace Tests.Hosting.Owin
     {
       server = new TestServer(
         new WebHostBuilder()
-          .Configure(app =>
-            app.UseOwin(builder =>
+          .Configure(app => app
+            .Use(next => async httpContext =>
+            {
+              try
+              {
+                await next(httpContext);
+              }
+              catch(Exception ex)
+              {
+                // Default behavior is to write the stack trace
+                httpContext.Response.StatusCode = 500;
+
+                // Incredibly annoying TargetInvocationException
+                var message = ex.InnerException?.Message ?? ex.Message;
+                await httpContext.Response.WriteAsync(message);
+              }
+            })
+            .UseOwin(builder =>
               builder.UseOpenRasta(
                 new TaskApi(),
+                startupProperties: new OpenRasta.Concordia.StartupProperties
+                {
+                  OpenRasta =
+                  {
+                    Errors =
+                    {
+                      HandleAllExceptions = false,
+                      HandleCatastrophicExceptions = false,
+                    },
+                  },
+                },
                 onAppDisposing: app.ApplicationServices.GetService<IApplicationLifetime>().ApplicationStopping))));
       client = server.CreateClient();
     }
@@ -50,6 +78,15 @@ namespace Tests.Hosting.Owin
       response.EnsureSuccessStatusCode();
       response.Content.Headers.ContentLength.ShouldBe(0);
     }
+
+    [Fact]
+    public async void can_get_handled_exception()
+    {
+      var response = await client.GetAsync("ping-exception");
+      response.StatusCode.ShouldBe(System.Net.HttpStatusCode.InternalServerError);
+      (await response.Content.ReadAsStringAsync()).ShouldBe("This is a test exception");
+    }
+
     public void Dispose()
     {
       server?.Dispose();

--- a/src/Tests/Infrastructure/TaskApi.cs
+++ b/src/Tests/Infrastructure/TaskApi.cs
@@ -27,6 +27,7 @@ namespace Tests.Infrastructure
         .ResourcesNamed("health")
         .AtUri("/ping-silently").Named("Silent")
         .And.AtUri("/ping-empty-content").Named("NoContent")
+        .And.AtUri("/ping-exception").Named("Exception")
         .HandledBy<TaskApiHealthHandler>();
 
       ResourceSpace.Has

--- a/src/Tests/Infrastructure/TaskApiHealthHandler.cs
+++ b/src/Tests/Infrastructure/TaskApiHealthHandler.cs
@@ -9,5 +9,7 @@ namespace Tests.Infrastructure
     }
 
     public OperationResult.OK GetNoContent() => new OperationResult.OK();
+
+    public OperationResult.OK GetException() => throw new System.Exception("This is a test exception");
   }
 }


### PR DESCRIPTION
The OpenRasta OWIN middleware shouldn't `try`/`catch`/respond; at this point it's the host's responsibility to deal with unhandled errors.

IMO it would be more correct to remove this `try`/`catch` altogether, ~~but for now I've added `HandleAllExceptions` as a condition for handling exceptions that make it this far~~ and [Seb agrees](https://github.com/openrasta/openrasta-core/commit/13cc31fb9042b851bef1a9d7bfbd0f55b2fc7212) so I removed it.

cc https://github.com/ololabs/platform/pull/41594

Failing test:
![image](https://github.com/user-attachments/assets/edd790da-4045-4ac3-a8ad-6cfb500ea780)

Passing test:
![image](https://github.com/user-attachments/assets/48eb49c3-4c52-4645-9bc4-6d4c19014474)
