### PR TITLE
Allow enabling `ResponseRetryMiddleware` [OLO-106178]

### DIFF
--- a/src/OpenRasta/Concordia/Keys.cs
+++ b/src/OpenRasta/Concordia/Keys.cs
@@ -10,5 +10,6 @@
 
     public const string HandleCatastrophicExceptions = "openrasta.errors.HandleCatastrophicExceptions";
     public const string HandleAllExceptions = "openrasta.errors.HandleAllExceptions";
+    public const string EnableResponseRetryMiddleware = "openrasta.errors." + nameof(EnableResponseRetryMiddleware);
   }
 }

--- a/src/OpenRasta/Concordia/StartupProperties.cs
+++ b/src/OpenRasta/Concordia/StartupProperties.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using OpenRasta.Pipeline;
+using OpenRasta.Web.Internal;
 // ReSharper disable MemberCanBePrivate.Global
 
 namespace OpenRasta.Concordia
@@ -99,12 +100,23 @@ namespace OpenRasta.Concordia
       {
       }
 
+      /// <summary>
+      /// Adds <see cref="CatastrophicFailureMiddleware"/> to the pipeline,
+      /// which handles exceptions that escape the OpenRasta pipeline.
+      /// Responds with a plain text 500 that includes the exception stack trace.
+      /// </summary>
       public bool HandleCatastrophicExceptions
       {
         get => Get(Keys.HandleCatastrophicExceptions, true);
         set => Set(Keys.HandleCatastrophicExceptions, value);
       }
 
+      /// <summary>
+      /// Instructs <see cref="ResponseMiddleware"/> to catch exceptions,
+      /// which will <see cref="CommunicationContextExtensions.Abort"/> failed requests.
+      /// Also enables <see cref="ResponseRetryMiddleware"/> to render the error response.
+      /// Default: <see langword="true"/>.
+      /// </summary>
       public bool HandleAllExceptions {
         get => Get(Keys.HandleAllExceptions, true);
         set => Set(Keys.HandleAllExceptions, value);}

--- a/src/OpenRasta/Concordia/StartupProperties.cs
+++ b/src/OpenRasta/Concordia/StartupProperties.cs
@@ -120,6 +120,14 @@ namespace OpenRasta.Concordia
       public bool HandleAllExceptions {
         get => Get(Keys.HandleAllExceptions, true);
         set => Set(Keys.HandleAllExceptions, value);}
+
+      /// <summary>
+      /// Enables <see cref="ResponseRetryMiddleware"/> even if <see cref="HandleAllExceptions"/> is <see langword="false"/>.
+      /// Default: <see langword="false"/>.
+      /// </summary>
+      public bool EnableResponseRetryMiddleware {
+        get => Get(Keys.EnableResponseRetryMiddleware, false);
+        set => Set(Keys.EnableResponseRetryMiddleware, value);}
     }
   }
 }

--- a/src/OpenRasta/Pipeline/PipelineBuildingExtensions.cs
+++ b/src/OpenRasta/Pipeline/PipelineBuildingExtensions.cs
@@ -33,7 +33,7 @@ namespace OpenRasta.Pipeline
           {
             converter = CreateResponseMiddleware;
             var errors = startupProperties?.OpenRasta.Errors;
-            if (errors?.HandleAllExceptions == true)
+            if (errors?.EnableResponseRetryMiddleware == true || errors?.HandleAllExceptions == true)
               yield return (new ResponseRetryMiddleware(), null);
             break;
           }

--- a/src/OpenRasta/Pipeline/PipelineBuildingExtensions.cs
+++ b/src/OpenRasta/Pipeline/PipelineBuildingExtensions.cs
@@ -32,7 +32,8 @@ namespace OpenRasta.Pipeline
           case KnownStages.IOperationResultInvocation _:
           {
             converter = CreateResponseMiddleware;
-            if (startupProperties?.OpenRasta.Errors.HandleAllExceptions == true)
+            var errors = startupProperties?.OpenRasta.Errors;
+            if (errors?.HandleAllExceptions == true)
               yield return (new ResponseRetryMiddleware(), null);
             break;
           }

--- a/src/OpenRasta/Pipeline/ResponseRetryMiddleware.cs
+++ b/src/OpenRasta/Pipeline/ResponseRetryMiddleware.cs
@@ -6,6 +6,10 @@ using OpenRasta.Web.Internal;
 namespace OpenRasta.Pipeline
 {
   
+  /// <summary>
+  /// Tries rendering a response if invoking the rest of the pipeline throws an exception
+  /// or the final <see cref="PipelineData.PipelineStage"/> is <see cref="PipelineContinuation.RenderNow"/>.
+  /// </summary>
   public class ResponseRetryMiddleware : IPipelineMiddlewareFactory, IPipelineMiddleware
   {
     IPipelineMiddleware _responsePipeline;

--- a/src/OpenRasta/Web/Internal/CommunicationContextExtensions.cs
+++ b/src/OpenRasta/Web/Internal/CommunicationContextExtensions.cs
@@ -14,6 +14,12 @@ namespace OpenRasta.Web.Internal
         .MakeAbsolute("http://localhost");
     }
 
+    /// <summary>
+    /// Aborts the current pipeline execution and sets the response to a 500 Internal Server Error.
+    /// The response resource contains <see cref="ICommunicationContext.ServerErrors"/>.
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="e"></param>
     public static void Abort(this ICommunicationContext context, Exception e = null)
     {
 #pragma warning disable 618


### PR DESCRIPTION
We've set `HandleAllExceptions = false` to skip this `Abort()`:
https://github.com/ololabs/openrasta-core/blob/db0bbe2a9565f6ede55859c2b9bd94771381110b/src/OpenRasta/Pipeline/RequestMiddleware.cs#L39-L42

But now the result from our pipeline contributor that tries to handle `ServerErrors` does not actually get rendered. I ~~suspect~~ have confirmed that's because we're missing `ResponseRetryMiddleware`:
https://github.com/ololabs/openrasta-core/blob/db0bbe2a9565f6ede55859c2b9bd94771381110b/src/OpenRasta/Pipeline/PipelineBuildingExtensions.cs#L35-L36

I've added an `EnableResponseRetryMiddleware` setting to reenable without `HandleAllExceptions`. Default is `false` to default to existing behavior according to `HandleAllExceptions`.

cc https://github.com/ololabs/platform/pull/41781